### PR TITLE
Protocol type version fix

### DIFF
--- a/Actions/Dockerfile/action.yml
+++ b/Actions/Dockerfile/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'The chosen name of the artifact. E.g. MyPackageName.  Required for stages: All, Upload and Deploy.'
     required: false
   version:
-    description: 'The version number for the artifact. Only required for a release run. (format A.B.C). E.g. 1.0.1. Required for stages Upload and All if no build number was provided instead.'
+    description: 'The version number for the artifact. Format A.B.C for a stable release or A.B.C-text for a pre-release. E.g. 1.0.1. Required for stages Upload and All if no build number was provided instead.'
     required: false
   timeout:
     description: 'The maximum time spend on waiting for the deployment to finish in seconds. E.g. 900.'

--- a/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
+++ b/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
@@ -33,7 +33,7 @@ public static class ApiExtensions
             var options = s.GetService<ApiOptions>();
             var presenter = s.GetService<ConsolePackagePresenter>();
             httpClient.BaseAddress = new Uri($"{options.ApiBaseUrl}/");
-            return new HttpArtifactUploadApi(presenter, httpClient);
+            return new HttpArtifactUploadApi(httpClient);
         });
     }
 }

--- a/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
+++ b/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
@@ -31,8 +31,9 @@ public static class ApiExtensions
         {
             var httpClient = s.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(HttpArtifactUploadApi));
             var options = s.GetService<ApiOptions>();
+            var presenter = s.GetService<ConsolePackagePresenter>();
             httpClient.BaseAddress = new Uri($"{options.ApiBaseUrl}/");
-            return new HttpArtifactUploadApi(httpClient);
+            return new HttpArtifactUploadApi(presenter, httpClient);
         });
     }
 }

--- a/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
+++ b/GitHubAction/GitHubAction.Console/Extensions/ApiExtensions.cs
@@ -31,7 +31,6 @@ public static class ApiExtensions
         {
             var httpClient = s.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(HttpArtifactUploadApi));
             var options = s.GetService<ApiOptions>();
-            var presenter = s.GetService<ConsolePackagePresenter>();
             httpClient.BaseAddress = new Uri($"{options.ApiBaseUrl}/");
             return new HttpArtifactUploadApi(httpClient);
         });

--- a/GitHubAction/GitHubAction.Console/Program.cs
+++ b/GitHubAction/GitHubAction.Console/Program.cs
@@ -46,9 +46,9 @@ public class Program
         Host.CreateDefaultBuilder(args)
             .ConfigureServices((hostContext, services) =>
             {
+                services.AddScoped<IPackagePresenter, ConsolePackagePresenter>();
                 services.AddScoped<GitHubAction>();
                 services.AddHttpClient();
-                services.AddScoped<IPackagePresenter, ConsolePackagePresenter>();
                 services.AddSingleton<ApiOptions>(sp =>
                 {
                     var environment = Environment.GetEnvironmentVariable("Skyline-deploy-action-namespace");

--- a/GitHubAction/GitHubAction.UnitTest/GitHubActionTests.cs
+++ b/GitHubAction/GitHubAction.UnitTest/GitHubActionTests.cs
@@ -107,7 +107,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -229,7 +229,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -426,7 +426,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -549,7 +549,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -679,7 +679,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -808,7 +808,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -937,7 +937,7 @@ namespace GitHubAction.UnitTest
 
             // Mocks
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -1046,7 +1046,7 @@ namespace GitHubAction.UnitTest
 
             // Mocks
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -1154,7 +1154,7 @@ namespace GitHubAction.UnitTest
 
             // Mocks
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var uploadedPackage = new UploadedPackage(id);
 
@@ -1263,7 +1263,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             var ex = new UploadPackageException("this should be thrown in the test", new Exception("inner exception"));
 
@@ -1357,7 +1357,7 @@ namespace GitHubAction.UnitTest
                 .ReturnsAsync(createdPackage);
 
             Expression<Func<IPackageService, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), key);
+                s.UploadPackageAsync(It.IsAny<CreatedPackage>(), version, key);
 
             _packageServiceMock
                 .Setup(uploadPackageAsync)

--- a/GitHubAction/GitHubAction.UnitTest/ParseInputsTest.cs
+++ b/GitHubAction/GitHubAction.UnitTest/ParseInputsTest.cs
@@ -580,58 +580,6 @@ public class ParseInputsTest
     }
 
     [Test]
-    [TestCase("All", true)]
-    [TestCase("Upload", true)]
-    [TestCase("Deploy", false)]
-    public void ParseAndValidateInputs_InvalidVersion(string stage, bool required)
-    {
-        // Given
-        var key = "some key";
-        var solutionFile = "solution-path";
-        var packageName = "TestPackage";
-        var version = "sqdfsdg";
-        var timeOut = "900";
-        var artifactId = "some string";
-
-        var args = new string[]
-        {
-            "--api-key",
-            key,
-            "--solution-path",
-            solutionFile,
-            "--artifact-name",
-            packageName,
-            "--version",
-            version,
-            "--timeout",
-            timeOut,
-            "--stage",
-            stage,
-            "--artifact-id",
-            artifactId,
-            "--base-path",
-            ""
-        };
-
-        // When
-        var inputs = _inputParserService.ParseAndValidateInputs(args)!;
-
-        // Then
-        if (required) _inputParserPresenterMock.Verify(p => p.PresentInvalidVersionFormat(), Times.Once);
-        _inputParserPresenterMock.Verify(p => p.PresentLogging(It.IsAny<string>()), Times.AtMost(100));
-        _inputParserPresenterMock.VerifyNoOtherCalls();
-
-        if (required)
-        {
-            Assert.IsNull(inputs);
-        }
-        else
-        {
-            Assert.IsNotNull(inputs);
-        }
-    }
-
-    [Test]
     public void ParseAndValidateInputs_InvalidTimeOut_NotAValidInt()
     {
         // Given

--- a/GitHubAction/GitHubAction/ConsolePackagePresenter.cs
+++ b/GitHubAction/GitHubAction/ConsolePackagePresenter.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+
 using Package.Builder;
 using Package.Domain.Exceptions;
 using Package.Domain.Models;
@@ -37,7 +38,7 @@ public class ConsolePackagePresenter : IPackagePresenter
 
     public void PresentPackageUploadFailed(UploadPackageException e)
     {
-        _logger.LogError("The package could not be uploaded.");
+        _logger.LogError("The package could not be uploaded. " + e);
     }
 
     public void PresentStartingPackageUpload()

--- a/GitHubAction/GitHubAction/ConsolePackagePresenter.cs
+++ b/GitHubAction/GitHubAction/ConsolePackagePresenter.cs
@@ -70,6 +70,11 @@ public class ConsolePackagePresenter : IPackagePresenter
         _logger.LogInformation("Waiting another {backOffSeconds} seconds for the package deployment to finish...", backOffDelaySeconds);
     }
 
+    public void LogInformation(string message)
+    {
+        _logger.LogInformation(message);
+    }
+
     public void PresentStartCreatingPackage()
     {
         _logger.LogInformation("Start creating package...");

--- a/GitHubAction/GitHubAction/Factories/Impl/InputFactory.cs
+++ b/GitHubAction/GitHubAction/Factories/Impl/InputFactory.cs
@@ -111,8 +111,8 @@ public class InputFactory : IInputFactory
 
                 if (!argumentsAreValid) return null;
 
-                if(isVersionPresent)
-                    argumentsAreValid &= ValidateVersion(InputArgurments.Version, version);
+                //if(isVersionPresent)
+                //    argumentsAreValid &= ValidateVersion(InputArgurments.Version, version);
 
                 if (!argumentsAreValid) return null;
 
@@ -171,16 +171,16 @@ public class InputFactory : IInputFactory
         return true;
     }
 
-    private bool ValidateVersion(string key, string? version)
-    {
-        if(version == null || (version != "" && !Regex.IsMatch(version, "[0-9]+.[0-9]+.[0-9]+(-CU[0-9]+)?") && !Regex.IsMatch(version, "[0-9]+.[0-9]+.[0-9]+.[0-9]")))
-        {
-            _presenter.PresentInvalidVersionFormat();
-            return false;
-        }
+    //private bool ValidateVersion(string key, string? version)
+    //{
+    //    if(version == null || (version != "" && !Regex.IsMatch(version, "[0-9]+.[0-9]+.[0-9]+(-CU[0-9]+)?") && !Regex.IsMatch(version, "[0-9]+.[0-9]+.[0-9]+.[0-9]")))
+    //    {
+    //        _presenter.PresentInvalidVersionFormat();
+    //        return false;
+    //    }
 
-        return true;
-    }
+    //    return true;
+    //}
 
     private bool ValidateTimeout(string? timeOutInSecondsString, out TimeSpan timeout)
     {

--- a/GitHubAction/Package.Application.UnitTest/PackageServiceTest.cs
+++ b/GitHubAction/Package.Application.UnitTest/PackageServiceTest.cs
@@ -67,7 +67,7 @@ namespace Package.Application.UnitTest
             var key = "key";
 
             Expression<Func<IPackageGateway, Task<UploadedPackage>>> uploadPackageAsync = s =>
-                s.UploadPackageAsync(createdPackage, key);
+                s.UploadPackageAsync(createdPackage, "version", key);
 
             var uploadedPackage = new UploadedPackage(Guid.NewGuid().ToString());
             _packageGatewayMock
@@ -75,7 +75,7 @@ namespace Package.Application.UnitTest
                 .ReturnsAsync(uploadedPackage);
 
             // When
-            var result = await _packageService.UploadPackageAsync(createdPackage, key);
+            var result = await _packageService.UploadPackageAsync(createdPackage,"version", key);
 
             // Then
             Assert.AreEqual(uploadedPackage, result);

--- a/GitHubAction/Package.Application/PackageService.cs
+++ b/GitHubAction/Package.Application/PackageService.cs
@@ -19,9 +19,9 @@ public class PackageService : IPackageService
         return await _packageBuilder.CreatePackageAsync(localPackageConfig);
     }
 
-    public async Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string key)
+    public async Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage,string catalogVersion, string key)
     {
-        return await _packageGateway.UploadPackageAsync(createdPackage, key);
+        return await _packageGateway.UploadPackageAsync(createdPackage,catalogVersion, key);
     }
 
     public async Task<DeployingPackage> DeployPackageAsync(UploadedPackage uploadedPackage, string key)

--- a/GitHubAction/Package.Builder/Package.Builder.csproj
+++ b/GitHubAction/Package.Builder/Package.Builder.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.DMApp.Automation" Version="1.0.0-AllowTaggingPrerelease.3" />
+    <PackageReference Include="Skyline.DataMiner.CICD.DMApp.Automation" Version="1.0.0.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitHubAction/Package.Builder/Package.Builder.csproj
+++ b/GitHubAction/Package.Builder/Package.Builder.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Skyline.DataMiner.CICD.DMApp.Automation" Version="1.0.0.16" />
+    <PackageReference Include="Skyline.DataMiner.CICD.DMApp.Automation" Version="1.0.0-AllowTaggingPrerelease.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitHubAction/Package.Builder/PackageBuilder.cs
+++ b/GitHubAction/Package.Builder/PackageBuilder.cs
@@ -76,7 +76,7 @@
                 {
                     version = DMAppVersion.FromDataMinerVersion(localPackageConfig.Version);
                 }
-                else if (Regex.IsMatch(localPackageConfig.Version, "[0-9]+.[0-9]+.[0-9]+.[0-9]"))
+                else if (Regex.IsMatch(localPackageConfig.Version, "[0-9]+.[0-9]+.[0-9]+.[0-9]$"))
                 {
                     version = DMAppVersion.FromProtocolVersion(localPackageConfig.Version);
                 }

--- a/GitHubAction/Package.Builder/PackageBuilder.cs
+++ b/GitHubAction/Package.Builder/PackageBuilder.cs
@@ -76,11 +76,15 @@
                 {
                     version = DMAppVersion.FromDataMinerVersion(localPackageConfig.Version);
                 }
-                else
+                else if (Regex.IsMatch(localPackageConfig.Version, "[0-9]+.[0-9]+.[0-9]+.[0-9]"))
                 {
                     version = DMAppVersion.FromProtocolVersion(localPackageConfig.Version);
                 }
-
+                else
+                {
+                    // Supports pre-releases
+                    version = DMAppVersion.FromPreRelease(localPackageConfig.Version);
+                }
             }
             else
             {

--- a/GitHubAction/Package.Domain/Services/IPackageGateway.cs
+++ b/GitHubAction/Package.Domain/Services/IPackageGateway.cs
@@ -13,7 +13,7 @@ public interface IPackageGateway
     /// <returns>The uploaded package if succeeded.</returns>
     /// <exception cref="KeyException">When the <paramref name="key"/> isn't valid or authorized to execute this action.</exception>
     /// <exception cref="UploadPackageException">When something went wrong while uploading the package.</exception>
-    Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string key);
+    Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage,string catalogVersion, string key);
 
     /// <summary>
     /// Starts the deployment of the package on the DMS.

--- a/GitHubAction/Package.Domain/Services/IPackagePresenter.cs
+++ b/GitHubAction/Package.Domain/Services/IPackagePresenter.cs
@@ -24,5 +24,6 @@ namespace Package.Domain.Services
         void PresentStartingPackageDeploymentFailed(DeployPackageException e);
         void PresentPackageCreationLogging(string line);
         void PresentPackageDeploymentFailed(DeployedPackage deployedPackage);
+        void LogInformation(string message);
     }
 }

--- a/GitHubAction/Package.Domain/Services/IPackageService.cs
+++ b/GitHubAction/Package.Domain/Services/IPackageService.cs
@@ -24,7 +24,7 @@ public interface IPackageService
     /// <returns>The uploaded package if succeeded.</returns>
     /// <exception cref="KeyException">When the <paramref name="key"/> isn't valid or authorized to execute this action.</exception>
     /// <exception cref="UploadPackageException">When something went wrong while uploading the package.</exception>
-    Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string key);
+    Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage,string catalogVersion, string key);
 
     /// <summary>
     /// Starts the deployment of the package on the DMS.

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -31,6 +31,7 @@ public class HttpPackageGateway : IPackageGateway
     {
         try
         {
+            _packagePresenter.LogInformation("Calling Artifact Upload.");
             var res = await _artifactUploadApi.ArtifactUploadV11PrivateArtifactPostAsync(
                 createdPackage.Package,
                 createdPackage.Name,

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -31,7 +31,7 @@ public class HttpPackageGateway : IPackageGateway
     {
         try
         {
-            _packagePresenter.LogInformation("Calling Artifact Upload.");
+            _packagePresenter.LogInformation("Calling Artifact Upload");
             var res = await _artifactUploadApi.ArtifactUploadV11PrivateArtifactPostAsync(
                 createdPackage.Package,
                 createdPackage.Name,

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -14,12 +14,14 @@ namespace Package.Gateway;
 public class HttpPackageGateway : IPackageGateway
 {
     private readonly IArtifactUploadApi _artifactUploadApi;
+    private readonly IPackagePresenter _packagePresenter;
     private readonly IArtifactDeploymentInfoAPI _artifactDeploymentInfoApi;
     private readonly IDeployArtifactAPI _deployArtifactApi;
     private const string DeploymentInfoKey = "DeploymentInfo";
 
-    public HttpPackageGateway(IArtifactUploadApi artifactUploadApi, IArtifactDeploymentInfoAPI artifactDeploymentInfoApi, IDeployArtifactAPI deployArtifactApi)
+    public HttpPackageGateway(IPackagePresenter packagePresenter, IArtifactUploadApi artifactUploadApi, IArtifactDeploymentInfoAPI artifactDeploymentInfoApi, IDeployArtifactAPI deployArtifactApi)
     {
+        _packagePresenter = packagePresenter;
         _artifactUploadApi = artifactUploadApi;
         _artifactDeploymentInfoApi = artifactDeploymentInfoApi;
         _deployArtifactApi = deployArtifactApi;

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -38,7 +38,7 @@ public class HttpPackageGateway : IPackageGateway
                 catalogVersion,
                 createdPackage.Type,
                 key,
-                default);
+                default, _packagePresenter);
 
             if (res.ArtifactId == null) throw new UploadPackageException("Received an invalid upload response");
 

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -50,7 +50,7 @@ public class HttpPackageGateway : IPackageGateway
         }
         catch (Exception e)
         {
-            throw new UploadPackageException($"Couldn't upload the package. Error message: {e.Message}");
+            throw new UploadPackageException($"Couldn't upload the package. Error message: {e}");
         }
     }
 
@@ -63,7 +63,7 @@ public class HttpPackageGateway : IPackageGateway
         }
         catch (Exception e)
         {
-            throw new DeployPackageException($"Couldn't deploy the package {e.ToString()}", e);
+            throw new DeployPackageException($"Couldn't deploy the package {e}", e);
         }
 
         if (res.Response.IsSuccessStatusCode)

--- a/GitHubAction/Package.Gateway/HttpPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/HttpPackageGateway.cs
@@ -25,14 +25,14 @@ public class HttpPackageGateway : IPackageGateway
         _deployArtifactApi = deployArtifactApi;
     }
 
-    public async Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string key)
+    public async Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string catalogVersion, string key)
     {
         try
         {
             var res = await _artifactUploadApi.ArtifactUploadV11PrivateArtifactPostAsync(
                 createdPackage.Package,
                 createdPackage.Name,
-                createdPackage.Version,
+                catalogVersion,
                 createdPackage.Type,
                 key,
                 default);

--- a/GitHubAction/Package.Gateway/MockedPackageGateway.cs
+++ b/GitHubAction/Package.Gateway/MockedPackageGateway.cs
@@ -5,7 +5,7 @@ namespace Package.Gateway;
 
 public class MockedPackageGateway : IPackageGateway
 {
-    public Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string key)
+    public Task<UploadedPackage> UploadPackageAsync(CreatedPackage createdPackage, string catalogVersion, string key)
     {
         return Task.FromResult(new UploadedPackage(Guid.NewGuid().ToString()));
     }

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -1,17 +1,20 @@
 ﻿using Package.Domain.Exceptions;
 using System.Net;
 using Newtonsoft.Json;
+using Package.Domain.Services;
 
 namespace UploadArtifactApi;
 
 public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
 {
     private readonly HttpClient _httpClient;
+    private readonly IPackagePresenter _presenter;
     private const string UploadPath = "api/key-artifact-upload/v1-0/private/artifact";
 
-    public HttpArtifactUploadApi(HttpClient httpClient)
+    public HttpArtifactUploadApi(IPackagePresenter presenter, HttpClient httpClient)
     {
         _httpClient = httpClient;
+        _presenter = presenter;
     }
 
     public async Task<PrivateArtifactModel> ArtifactUploadV11PrivateArtifactPostAsync(
@@ -33,7 +36,7 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
         formData.Add(new StringContent(contentType), "contentType");
         formData.Add(new StreamContent(fileStream), "file", Path.GetFileName(fileStream.Name));
 
-
+        _presenter.LogInformation("Posting Call: "+ formData.ToString());
         var response = await _httpClient.PostAsync(UploadPath, formData, cancellationToken);
 
         if (response.IsSuccessStatusCode)

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -19,20 +19,20 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
     }
 
     public async Task<PrivateArtifactModel> ArtifactUploadV11PrivateArtifactPostAsync(
-        byte[] package, 
-        string name, 
-        string version, 
-        string contentType, 
-        string key, 
+        byte[] package,
+        string name,
+        string version,
+        string contentType,
+        string key,
         CancellationToken cancellationToken)
     {
         string dmappFilePath = Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), name);
-		File.WriteAllBytes(dmappFilePath, package);
-		FileStream fileStream = new FileStream(dmappFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
+        File.WriteAllBytes(dmappFilePath, package);
+        FileStream fileStream = new FileStream(dmappFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
 
         StringBuilder sb = new StringBuilder();
 
-		using var formData = new MultipartFormDataContent();
+        using var formData = new MultipartFormDataContent();
         formData.Headers.Add("Ocp-Apim-Subscription-Key", key);
         formData.Add(new StringContent(name), "name");
         formData.Add(new StringContent(version), "version");
@@ -48,10 +48,10 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
 
         if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
         {
-            throw new KeyException($"The upload api returned a {response.StatusCode} response.");
+            throw new KeyException($"The upload api returned a {response.StatusCode} response. Body:" + response?.Content?.ToString() ?? "null");
         }
 
-        throw new UploadPackageException($"The upload api returned a {response.StatusCode} response.");
+        throw new UploadPackageException($"The upload api returned a {response.StatusCode} response. Body:" + response?.Content?.ToString() ?? "null");
     }
 
     public void Dispose()

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -39,6 +39,10 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
         formData.Add(new StringContent(contentType), "contentType");
         formData.Add(new StreamContent(fileStream), "file", Path.GetFileName(fileStream.Name));
 
+        string logInfo = $"--name {name} --version {version} --contentType {contentType} --file {Path.GetFileName(fileStream.Name)}";
+
+        _presenter.LogInformation("HTTP Post with info: " + logInfo);
+
         var response = await _httpClient.PostAsync(UploadPath, formData, cancellationToken);
 
         if (response.IsSuccessStatusCode)

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -39,7 +39,6 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
         formData.Add(new StringContent(contentType), "contentType");
         formData.Add(new StreamContent(fileStream), "file", Path.GetFileName(fileStream.Name));
 
-        _presenter.LogInformation("Posting Call: "+ formData.ToString());
         var response = await _httpClient.PostAsync(UploadPath, formData, cancellationToken);
 
         if (response.IsSuccessStatusCode)

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -9,13 +9,11 @@ namespace UploadArtifactApi;
 public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
 {
     private readonly HttpClient _httpClient;
-    private readonly IPackagePresenter _presenter;
     private const string UploadPath = "api/key-artifact-upload/v1-0/private/artifact";
 
-    public HttpArtifactUploadApi(IPackagePresenter presenter, HttpClient httpClient)
+    public HttpArtifactUploadApi(HttpClient httpClient)
     {
         _httpClient = httpClient;
-        _presenter = presenter;
     }
 
     public async Task<PrivateArtifactModel> ArtifactUploadV11PrivateArtifactPostAsync(
@@ -24,7 +22,7 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
         string version,
         string contentType,
         string key,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken, IPackagePresenter presenter)
     {
         string dmappFilePath = Path.Combine(Environment.GetEnvironmentVariable("GITHUB_WORKSPACE"), name);
         File.WriteAllBytes(dmappFilePath, package);
@@ -40,8 +38,7 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
         formData.Add(new StreamContent(fileStream), "file", Path.GetFileName(fileStream.Name));
 
         string logInfo = $"--name {name} --version {version} --contentType {contentType} --file {Path.GetFileName(fileStream.Name)}";
-
-        _presenter.LogInformation("HTTP Post with info: " + logInfo);
+        presenter.LogInformation("HTTP Post with info: " + logInfo);
 
         var response = await _httpClient.PostAsync(UploadPath, formData, cancellationToken);
 

--- a/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/HttpArtifactUploadApi.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using Newtonsoft.Json;
 using Package.Domain.Services;
+using System.Text;
 
 namespace UploadArtifactApi;
 
@@ -29,9 +30,11 @@ public class HttpArtifactUploadApi : IArtifactUploadApi, IDisposable
 		File.WriteAllBytes(dmappFilePath, package);
 		FileStream fileStream = new FileStream(dmappFilePath, FileMode.Open, FileAccess.Read, FileShare.None);
 
+        StringBuilder sb = new StringBuilder();
+
 		using var formData = new MultipartFormDataContent();
         formData.Headers.Add("Ocp-Apim-Subscription-Key", key);
-        formData.Add(new StringContent(name), "name"); 
+        formData.Add(new StringContent(name), "name");
         formData.Add(new StringContent(version), "version");
         formData.Add(new StringContent(contentType), "contentType");
         formData.Add(new StreamContent(fileStream), "file", Path.GetFileName(fileStream.Name));

--- a/GitHubAction/UploadArtifactApi/IArtifactUploadApi.cs
+++ b/GitHubAction/UploadArtifactApi/IArtifactUploadApi.cs
@@ -1,4 +1,5 @@
 ﻿using Package.Domain.Exceptions;
+using Package.Domain.Services;
 
 namespace UploadArtifactApi;
 
@@ -16,5 +17,5 @@ public interface IArtifactUploadApi
     /// <returns>The uploaded package if succeeded.</returns>
     /// <exception cref="KeyException">When the <paramref name="key"/> isn't valid or authorized to execute this action.</exception>
     /// <exception cref="UploadPackageException">When something went wrong while uploading the package.</exception>
-    Task<PrivateArtifactModel> ArtifactUploadV11PrivateArtifactPostAsync(byte[] package, string name, string version, string contentType, string key, CancellationToken cancellationToken);
+    Task<PrivateArtifactModel> ArtifactUploadV11PrivateArtifactPostAsync(byte[] package, string name, string version, string contentType, string key, CancellationToken cancellationToken, IPackagePresenter presenter);
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This action currently only supports the creation of artifacts with Automation sc
 ### `version`
 
 **Optional**.
-The version number for the artifact. Only required for a release run. (format A.B.C). E.g. `'1.0.1'`. Required for stages `'Upload'` and `'All'` if no build-number was provided instead.
+The version number for the artifact. Only required for a release run. Format A.B.C for a stable release or A.B.C-text for a pre-release. E.g. `'1.0.1'`. Required for stages `'Upload'` and `'All'` if no build-number was provided instead.
 
 ### `timeout`
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'The chosen name of the artifact. E.g. MyPackageName.  Required for stages: All, Upload and Deploy.'
     required: false
   version:
-    description: 'The version number for the artifact. Only required for a release run. The version number for the artifact. Format A.B.C for a stable release or A.B.C-text for a pre-release. Required for stages Upload and All if no build number was provided instead.'
+    description: 'The version number for the artifact. Only required for a release run. Format A.B.C for a stable release or A.B.C-text for a pre-release. Required for stages Upload and All if no build number was provided instead.'
     required: false
   timeout:
     description: 'The maximum time spent on waiting for the deployment to finish in seconds. E.g. 900.'

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'The chosen name of the artifact. E.g. MyPackageName.  Required for stages: All, Upload and Deploy.'
     required: false
   version:
-    description: 'The version number for the artifact. Only required for a release run. (format A.B.C). E.g. 1.0.1. Required for stages Upload and All if no build number was provided instead.'
+    description: 'The version number for the artifact. Only required for a release run. The version number for the artifact. Format A.B.C for a stable release or A.B.C-text for a pre-release. Required for stages Upload and All if no build number was provided instead.'
     required: false
   timeout:
     description: 'The maximum time spent on waiting for the deployment to finish in seconds. E.g. 900.'
@@ -38,7 +38,7 @@ outputs:
   
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/skylinecommunications/skyline-dataminer-deploy-action:1.0.17'
+  image: 'docker://ghcr.io/skylinecommunications/skyline-dataminer-deploy-action:1.0.18'
   args:
     - --api-key
     - ${{ inputs.api-key }}


### PR DESCRIPTION
* Allows tagging with pre-release versions. (Note, will still fail until further fixes in upload API)
* Improves logging and exception logging for deployments and uploads
*

Note: Before release, first release Reusable Modules and adjust the NuGet Package for dmapp creation in the deploy action.